### PR TITLE
fix: set requires-python to >=3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ keywords = "specification,standard,OZI,mesonbuild"
 license = {file = "LICENSE.txt"}
 readme = "README.rst"
 dependencies = ['setuptools_scm']
-requires-python = '>=3.10, <3.14'
+requires-python = '>=3.9, <3.14'
 classifiers = [
     'Development Status :: 3 - Alpha',
     'Programming Language :: Python :: 3 :: Only',


### PR DESCRIPTION
This fixes dependabot compatibility