### PR TITLE
fix: OZI.build~=2.0.8 - overwrite sdist version with supply-chain pro…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ Documentation = "https://docs.oziproject.dev/en/latest/ozi_spec.html"
 Homepage = "https://www.oziproject.dev"
 
 [build-system]
-requires = ['OZI.build[core,pip,uv]~=2.0.7', 'PyYAML']
+requires = ['OZI.build[core,pip,uv]~=2.0.8', 'PyYAML']
 build-backend = "ozi_build.buildapi"
 
 [tool.setuptools_scm]
@@ -302,7 +302,7 @@ package = wheel
 deps =
      uv
 commands_pre =
-     python -m uv pip install OZI.build[core,pip,uv]~=2.0.7 PyYAML
+     python -m uv pip install OZI.build[core,pip,uv]~=2.0.8 PyYAML
      pipx install --python=python meson
 commands =
      meson setup {env_tmp_dir} -Dozi:dist=disabled -Dozi:tox-env-dir={env_dir}


### PR DESCRIPTION
…visioned version